### PR TITLE
chore: bump react native to `0.71.6`

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
 # You may use http://rbenv.org/ or https://rvm.io/ to install and use this version
-ruby File.read(File.join(__dir__, '.ruby-version')).strip
+ruby '>= 2.6.10'
 
-gem 'cocoapods', '~> 1.11', '>= 1.11.3'
+gem 'cocoapods', '>= 1.11.3'

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@tanstack/react-query": "^4.24.10",
     "apisauce": "^2.1.6",
     "react": "18.2.0",
-    "react-native": "0.71.4",
+    "react-native": "0.71.6",
     "react-native-app-auth": "^6.4.3",
     "react-native-blob-util": "^0.17.3",
     "react-native-gesture-handler": "^2.9.0",


### PR DESCRIPTION
### Summary ###
Bump react native version from `0.71.4` to `0.71.6` using [upgrade helper](https://react-native-community.github.io/upgrade-helper/?from=0.71.4&to=0.71.6)